### PR TITLE
Use custom color and client name in the SDKs

### DIFF
--- a/android/src/main/java/com/ticketmasterignite/AccountsSDKModule.kt
+++ b/android/src/main/java/com/ticketmasterignite/AccountsSDKModule.kt
@@ -108,7 +108,7 @@ class AccountsSDKModule(reactContext: ReactApplicationContext) :
         TicketsSDKClient
           .Builder()
           .authenticationSDKClient(authentication)
-          .colors(createTicketsColors(android.graphics.Color.parseColor("#231F20")))
+          .colors(createTicketsColors(android.graphics.Color.parseColor(Config.get("primaryColor"))))
           .build(currentFragmentActivity)
           .apply {
             TicketsSDKSingleton.setTicketsSdkClient(this)

--- a/android/src/main/java/com/ticketmasterignite/AccountsSDKModule.kt
+++ b/android/src/main/java/com/ticketmasterignite/AccountsSDKModule.kt
@@ -61,7 +61,7 @@ class AccountsSDKModule(reactContext: ReactApplicationContext) :
       val currentFragmentActivity = currentActivity as FragmentActivity
       val authentication = TMAuthentication.Builder()
         .apiKey(Config.get("apiKey"))
-        .clientName(Config.get("clientName")) // Team name to be displayed
+        .clientName(Config.get("clientName")) 
         .colors(TMAuthentication.ColorTheme())
         .environment(TMXDeploymentEnvironment.Production) // Environment that the SDK will use. Default is Production
         .region(TMXDeploymentRegion.US) // Region that the SDK will use. Default is US

--- a/android/src/main/java/com/ticketmasterignite/retail/PrePurchaseActivity.kt
+++ b/android/src/main/java/com/ticketmasterignite/retail/PrePurchaseActivity.kt
@@ -1,6 +1,7 @@
 package com.ticketmasterignite.retail
 
 import android.os.Bundle
+import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
@@ -22,10 +23,7 @@ class PrePurchaseActivity : AppCompatActivity() {
 
         val tmPrePurchase = TMPrePurchase(
                 discoveryAPIKey = Config.get("apiKey"),
-                brandColor = ContextCompat.getColor(
-                        this@PrePurchaseActivity,
-                        com.ticketmaster.prepurchase.R.color.black
-                )
+                brandColor = Color.parseColor(Config.get("primaryColor"))
         )
         val venueId = intent.getStringExtra("venueId")
         val attractionId = intent.getStringExtra("attractionId")

--- a/android/src/main/java/com/ticketmasterignite/retail/PurchaseActivity.kt
+++ b/android/src/main/java/com/ticketmasterignite/retail/PurchaseActivity.kt
@@ -1,6 +1,7 @@
 package com.ticketmasterignite.retail
 
 import android.os.Bundle
+import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.ticketmasterignite.R
@@ -19,10 +20,7 @@ class PurchaseActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             val tmPurchase = TMPurchase(
                     apiKey = Config.get("apiKey"),
-                    brandColor = ContextCompat.getColor(
-                            this,
-                            com.ticketmaster.prepurchase.R.color.black
-                    )
+                    brandColor = Color.parseColor(Config.get("primaryColor"))
             )
 
             val tmPurchaseWebsiteConfiguration = TMPurchaseWebsiteConfiguration(

--- a/android/src/main/java/com/ticketmasterignite/tickets/TicketsFragment.kt
+++ b/android/src/main/java/com/ticketmasterignite/tickets/TicketsFragment.kt
@@ -74,7 +74,7 @@ class TicketsFragment() : Fragment() {
             val authentication = TMAuthentication.Builder()
                 .apiKey(Config.get("apiKey"))
                 .clientName(Config.get("clientName")) 
-                .colors(createAuthColors(android.graphics.Color.parseColor("#000000")))
+                .colors(createAuthColors(android.graphics.Color.parseColor(Config.get("primaryColor"))))
                 .environment(TMXDeploymentEnvironment.Production) // Environment that the SDK will use. Default is Production
                 .region(TMXDeploymentRegion.US) // Region that the SDK will use. Default is US
                 .build(this@TicketsFragment.requireActivity())
@@ -84,7 +84,7 @@ class TicketsFragment() : Fragment() {
                 .Builder()
                 .authenticationSDKClient(authentication) //Authentication object
                 //Optional value to define the colors for the Tickets page
-                .colors(createTicketsColors(android.graphics.Color.parseColor("#000000")))
+                .colors(createTicketsColors(android.graphics.Color.parseColor(Config.get("primaryColor"))))
                 //Function that generates a TicketsSDKClient object
                 .build(this@TicketsFragment.requireActivity())
                 .apply {

--- a/android/src/main/java/com/ticketmasterignite/tickets/TicketsFragment.kt
+++ b/android/src/main/java/com/ticketmasterignite/tickets/TicketsFragment.kt
@@ -73,7 +73,7 @@ class TicketsFragment() : Fragment() {
         coroutineScope.launch(Dispatchers.Main) {
             val authentication = TMAuthentication.Builder()
                 .apiKey(Config.get("apiKey"))
-                .clientName(Config.get("clientName")) // Team name to be displayed
+                .clientName(Config.get("clientName")) 
                 .colors(createAuthColors(android.graphics.Color.parseColor("#000000")))
                 .environment(TMXDeploymentEnvironment.Production) // Environment that the SDK will use. Default is Production
                 .region(TMXDeploymentRegion.US) // Region that the SDK will use. Default is US

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -21,6 +21,7 @@ const App = () => {
           options={{
             apiKey: Config.API_KEY || '',
             clientName: Config.CLIENT_NAME || '',
+            primaryColor: Config.PRIMARY_COLOR || ''
           }}
         >
           <Root />

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -21,7 +21,7 @@ const App = () => {
           options={{
             apiKey: Config.API_KEY || '',
             clientName: Config.CLIENT_NAME || '',
-            primaryColor: Config.PRIMARY_COLOR || ''
+            primaryColor: Config.PRIMARY_COLOR || '',
           }}
         >
           <Root />

--- a/example/src/navigators/BottomTabs.tsx
+++ b/example/src/navigators/BottomTabs.tsx
@@ -5,6 +5,7 @@ import Home from '../screens/Home';
 import MyEvents from '../screens/MyEvents';
 import HomeIcon from '../assets/svg/HomeIcon';
 import MyEventsIcon from '../assets/svg/MyEventsIcon';
+import Config from 'react-native-config';
 
 const Tab = createBottomTabNavigator();
 
@@ -15,7 +16,7 @@ const BottomTabs = () => {
         headerTitleAlign: 'center',
         headerShown: true,
         headerStyle: {
-          backgroundColor: '#026cdf',
+          backgroundColor: Config.PRIMARY_COLOR,
         },
         headerTintColor: 'white',
         tabBarStyle: {
@@ -31,7 +32,7 @@ const BottomTabs = () => {
           position: 'absolute',
           bottom: 0,
         },
-        tabBarActiveTintColor: '#026cdf',
+        tabBarActiveTintColor: Config.PRIMARY_COLOR,
       }}
     >
       <Tab.Screen
@@ -40,7 +41,7 @@ const BottomTabs = () => {
         options={{
           tabBarLabel: 'Home',
           tabBarIcon: ({ focused }) => (
-            <HomeIcon fill={focused ? '#026cdf' : 'grey'} />
+            <HomeIcon fill={focused ? Config.PRIMARY_COLOR : 'grey'} />
           ),
         }}
       />
@@ -51,7 +52,7 @@ const BottomTabs = () => {
           tabBarLabel: 'Tickets SDK (Embedded)',
           unmountOnBlur: true,
           tabBarIcon: ({ focused }) => (
-            <MyEventsIcon fill={focused ? '#026cdf' : 'grey'} />
+            <MyEventsIcon fill={focused ? Config.PRIMARY_COLOR : 'grey'} />
           ),
         }}
       />

--- a/ios/AccountsSDK.swift
+++ b/ios/AccountsSDK.swift
@@ -14,8 +14,9 @@ class AccountsSDK: RCTEventEmitter, TMAuthenticationDelegate  {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
     
-    let branding = TMAuthentication.Branding(backgroundColor: .red,
-                                             theme: .light)
+    let primaryColor = Config.shared.get(for: "primaryColor")
+    let backgroundColor = UIColor(hexString: primaryColor) ?? AppConstants.defaultBrandColor 
+    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,
                                                                          branding: branding)

--- a/ios/AccountsSDK.swift
+++ b/ios/AccountsSDK.swift
@@ -8,8 +8,7 @@ class AccountsSDK: RCTEventEmitter, TMAuthenticationDelegate  {
   @objc public func configureAccountsSDK(_ resolve: @escaping (String) -> Void, reject: @escaping (_ code: String, _ message: String, _ error: NSError) -> Void) {
     
     TMAuthentication.shared.delegate = self
-    
-    
+
     // build a combination of Settings and Branding
     let apiKey = Config.shared.get(for: "apiKey") 
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,

--- a/ios/AccountsSDK.swift
+++ b/ios/AccountsSDK.swift
@@ -15,8 +15,7 @@ class AccountsSDK: RCTEventEmitter, TMAuthenticationDelegate  {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
     
-    let branding = TMAuthentication.Branding(displayName: "My Team",
-                                             backgroundColor: .red,
+    let branding = TMAuthentication.Branding(backgroundColor: .red,
                                              theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,

--- a/ios/AppConstants.swift
+++ b/ios/AppConstants.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+struct AppConstants {
+    static let defaultBrandColor = UIColor(hexString: "026cdf")
+}

--- a/ios/PrePurchaseSDK.swift
+++ b/ios/PrePurchaseSDK.swift
@@ -51,8 +51,7 @@ class PrePurchaseSDK: UIViewController, TMPrePurchaseNavigationDelegate {
                                                           region: .US)
 
     let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let branding = TMAuthentication.Branding(displayName: "My Team",
-                                             backgroundColor: UIColor(named: "brandColor") ?? defaultBrandColor,
+    let branding = TMAuthentication.Branding(backgroundColor: UIColor(named: "brandColor") ?? defaultBrandColor,
                                              theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,

--- a/ios/PrePurchaseSDK.swift
+++ b/ios/PrePurchaseSDK.swift
@@ -50,9 +50,11 @@ class PrePurchaseSDK: UIViewController, TMPrePurchaseNavigationDelegate {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
 
+    let primaryColor = Config.shared.get(for: "primaryColor")
     let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let branding = TMAuthentication.Branding(backgroundColor: UIColor(named: "brandColor") ?? defaultBrandColor,
-                                             theme: .light)
+    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+
+    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,
                                                                          branding: branding)
@@ -61,7 +63,7 @@ class PrePurchaseSDK: UIViewController, TMPrePurchaseNavigationDelegate {
       print("PrePurchase api key set result: \(isPrePurchaseApiSet)")
       TMDiscoveryAPI.shared.configure(apiKey: apiKey, completion: { isDiscoveryApiSet in
         print("Discovery api key set result: \(isDiscoveryApiSet)")
-        TMPrePurchase.shared.brandColor = UIColor(named: "brandColor") ?? defaultBrandColor!
+        TMPrePurchase.shared.brandColor = backgroundColor!
         
         print("Authentication SDK Configuring...")
         TMAuthentication.shared.configure(brandedServiceSettings: brandedServiceSettings) {

--- a/ios/PrePurchaseSDK.swift
+++ b/ios/PrePurchaseSDK.swift
@@ -51,8 +51,7 @@ class PrePurchaseSDK: UIViewController, TMPrePurchaseNavigationDelegate {
                                                           region: .US)
 
     let primaryColor = Config.shared.get(for: "primaryColor")
-    let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+    let backgroundColor = UIColor(hexString: primaryColor) ?? AppConstants.defaultBrandColor
 
     let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     
@@ -63,8 +62,9 @@ class PrePurchaseSDK: UIViewController, TMPrePurchaseNavigationDelegate {
       print("PrePurchase api key set result: \(isPrePurchaseApiSet)")
       TMDiscoveryAPI.shared.configure(apiKey: apiKey, completion: { isDiscoveryApiSet in
         print("Discovery api key set result: \(isDiscoveryApiSet)")
+
         TMPrePurchase.shared.brandColor = backgroundColor!
-        
+
         print("Authentication SDK Configuring...")
         TMAuthentication.shared.configure(brandedServiceSettings: brandedServiceSettings) {
           backendsConfigured in

--- a/ios/PurchaseSDK.swift
+++ b/ios/PurchaseSDK.swift
@@ -11,11 +11,9 @@ class PurchaseSDK: NSObject {
                                                           region: .US)
 
     let primaryColor = Config.shared.get(for: "primaryColor")
-    let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
-
-    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor,
-                                              theme: .light)
+    let backgroundColor = UIColor(hexString: primaryColor) ?? AppConstants.defaultBrandColor 
+    
+    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings, branding: branding)
     

--- a/ios/PurchaseSDK.swift
+++ b/ios/PurchaseSDK.swift
@@ -9,13 +9,15 @@ class PurchaseSDK: NSObject {
     let apiKey = Config.shared.get(for: "apiKey")
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
-    
+
+    let primaryColor = Config.shared.get(for: "primaryColor")
     let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let branding = TMAuthentication.Branding(backgroundColor: UIColor(named: "brandColor") ?? defaultBrandColor,
+    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+
+    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor,
                                               theme: .light)
     
-    let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,
-                                                                         branding: branding)
+    let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings, branding: branding)
     
     TMPurchase.shared.configure(apiKey: apiKey, completion: {
       isPurchaseApiSet in
@@ -25,7 +27,7 @@ class PurchaseSDK: NSObject {
         print("Discovery api key set result: \(isDiscoveryApiSet)")
         TMAuthentication.shared.configure(brandedServiceSettings: brandedServiceSettings) { backendsConfigured in
           
-          TMPurchase.shared.brandColor = UIColor(named: "brandColor") ?? defaultBrandColor!
+          TMPurchase.shared.brandColor = backgroundColor!
           
           TMTickets.shared.configure {
             

--- a/ios/PurchaseSDK.swift
+++ b/ios/PurchaseSDK.swift
@@ -11,8 +11,7 @@ class PurchaseSDK: NSObject {
                                                           region: .US)
     
     let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let branding = TMAuthentication.Branding(displayName: "My Team",
-                                              backgroundColor: UIColor(named: "brandColor") ?? defaultBrandColor,
+    let branding = TMAuthentication.Branding(backgroundColor: UIColor(named: "brandColor") ?? defaultBrandColor,
                                               theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,

--- a/ios/TicketsSdkEmbeddedViewController.swift
+++ b/ios/TicketsSdkEmbeddedViewController.swift
@@ -13,8 +13,7 @@ public class TicketsSdkEmbeddedViewController: UIViewController {
                                                           region: .US)
     
     let primaryColor = Config.shared.get(for: "primaryColor")
-    let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+    let backgroundColor = UIColor(hexString: primaryColor) ?? AppConstants.defaultBrandColor 
 
     let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     

--- a/ios/TicketsSdkEmbeddedViewController.swift
+++ b/ios/TicketsSdkEmbeddedViewController.swift
@@ -12,8 +12,11 @@ public class TicketsSdkEmbeddedViewController: UIViewController {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
     
-    let branding = TMAuthentication.Branding(backgroundColor: .init(hexString: "#026cdf"),
-                                             theme: .light)
+    let primaryColor = Config.shared.get(for: "primaryColor")
+    let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
+    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+
+    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,
                                                                          branding: branding)

--- a/ios/TicketsSdkEmbeddedViewController.swift
+++ b/ios/TicketsSdkEmbeddedViewController.swift
@@ -12,8 +12,7 @@ public class TicketsSdkEmbeddedViewController: UIViewController {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
     
-    let branding = TMAuthentication.Branding(displayName: "My Team",
-                                             backgroundColor: .init(hexString: "#026cdf"),
+    let branding = TMAuthentication.Branding(backgroundColor: .init(hexString: "#026cdf"),
                                              theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,

--- a/ios/TicketsSdkViewController.swift
+++ b/ios/TicketsSdkViewController.swift
@@ -12,8 +12,11 @@ public class TicketsSdkViewController: UIViewController {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
     
-    let branding = TMAuthentication.Branding(backgroundColor: .init(hexString: "#026cdf"),
-                                             theme: .light)
+    let primaryColor = Config.shared.get(for: "primaryColor")
+    let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
+    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+
+    let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,
                                                                          branding: branding)

--- a/ios/TicketsSdkViewController.swift
+++ b/ios/TicketsSdkViewController.swift
@@ -13,8 +13,7 @@ public class TicketsSdkViewController: UIViewController {
                                                           region: .US)
     
     let primaryColor = Config.shared.get(for: "primaryColor")
-    let defaultBrandColor = UIColor(hexString: "026cdf") // TM blue
-    let backgroundColor = UIColor(hexString: primaryColor) ?? defaultBrandColor
+    let backgroundColor = UIColor(hexString: primaryColor) ?? AppConstants.defaultBrandColor 
 
     let branding = TMAuthentication.Branding(backgroundColor: backgroundColor, theme: .light)
     

--- a/ios/TicketsSdkViewController.swift
+++ b/ios/TicketsSdkViewController.swift
@@ -12,8 +12,7 @@ public class TicketsSdkViewController: UIViewController {
     let tmxServiceSettings = TMAuthentication.TMXSettings(apiKey: apiKey,
                                                           region: .US)
     
-    let branding = TMAuthentication.Branding(displayName: "My Team",
-                                             backgroundColor: .init(hexString: "#026cdf"),
+    let branding = TMAuthentication.Branding(backgroundColor: .init(hexString: "#026cdf"),
                                              theme: .light)
     
     let brandedServiceSettings = TMAuthentication.BrandedServiceSettings(tmxSettings: tmxServiceSettings,

--- a/src/IgniteProvider.tsx
+++ b/src/IgniteProvider.tsx
@@ -6,6 +6,7 @@ interface IgniteProviderProps {
   options: {
     apiKey: string;
     clientName: string;
+    primaryColor: string;
   };
 }
 
@@ -50,7 +51,7 @@ export const IgniteProvider: React.FC<IgniteProviderProps> = ({
   options,
 }) => {
   const { Config, AccountsSDK } = NativeModules;
-  const { apiKey, clientName } = options;
+  const { apiKey, clientName, primaryColor } = options;
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [isLoggingIn, setIsLoggingIn] = useState<boolean>(false);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
@@ -61,6 +62,7 @@ export const IgniteProvider: React.FC<IgniteProviderProps> = ({
 
   Config.setConfig('apiKey', apiKey);
   Config.setConfig('clientName', clientName);
+  Config.setConfig('primaryColor', primaryColor);
 
   const setAccountDetails = async () => {
     try {


### PR DESCRIPTION
implements ICCPAPP-1759

ios

<img src="https://github.com/user-attachments/assets/07a08393-8996-4922-8d1d-8be125540388" width="200">
<img src="https://github.com/user-attachments/assets/d776496f-a622-4492-b21c-573a3ed1284a" width="200">
<img src="https://github.com/user-attachments/assets/63c87936-6b85-4bfb-abea-7d094a42b86a" width="200">

android

<img src="https://github.com/user-attachments/assets/6468e566-a6c6-47b3-b44e-5ac4cd6f0cb7" width="200">
<img src="https://github.com/user-attachments/assets/821fcdaa-4256-47f5-96ab-abf8acade1cb" width="200">
<img src="https://github.com/user-attachments/assets/0c1d68c9-1d4d-4145-9565-b58c2ba77179" width="200">
<img src="https://github.com/user-attachments/assets/647b0791-895f-4db1-b403-9b3b789401c1" width="200">
