### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,6 @@ return (
 
 #### TicketsSdkEmbedded
 
-iOS example:
-
 ```typescript
 
 import { TicketsSdkEmbedded } from 'react-native-ticketmaster-ignite';
@@ -303,15 +301,6 @@ React Navigation note: Initially, the altered RN Bottom Tabs View frame height i
 import { TicketsSdkEmbedded } from 'react-native-ticketmaster-ignite';
 
 return <TicketsSdkEmbedded style={{ height: '100%' }} renderTimeDelay={500}/>;
-```
-
-Android example:
-
-```typescript
-
-import { TicketsSdkEmbedded } from 'react-native-ticketmaster-ignite';
-
-return  <TicketsSdkEmbeddedAndroid />;
 ```
 
 #### SecureEntryView (Android only)

--- a/README.md
+++ b/README.md
@@ -302,6 +302,15 @@ import { TicketsSdkEmbedded } from 'react-native-ticketmaster-ignite';
 
 return <TicketsSdkEmbedded style={{ height: '100%' }} renderTimeDelay={500}/>;
 ```
+⚠️  Please note that `style` and `renderTimeDelay` are props only used on ios.
+The Android implementation is always as simple as this:
+
+```typescript
+
+import { TicketsSdkEmbedded } from 'react-native-ticketmaster-ignite';
+
+return <TicketsSdkEmbedded />;
+```
 
 #### SecureEntryView (Android only)
 


### PR DESCRIPTION
We no longer export platform-specific embedded tickets component - we distinguish the platforms within the library (see `src/TicketsSdkEmbedded.tsx`). Removed the platform mention as it's no longer up to date. 