### PR TITLE
fix: prevent premature deallocation of embedded tickets view controller

### DIFF
--- a/ios/RNTTicketsSdkEmbeddedViewManager.m
+++ b/ios/RNTTicketsSdkEmbeddedViewManager.m
@@ -8,6 +8,7 @@
 #endif
 
 @interface RNTTicketsSdkEmbeddedViewManager : RCTViewManager
+@property (strong) TicketsSdkEmbeddedViewController *ticketsViewController;
 @end
 
 @implementation RNTTicketsSdkEmbeddedViewManager
@@ -26,11 +27,10 @@ RCT_EXPORT_MODULE(RNTTicketsSdkEmbeddedView)
 
 - (UIView *)view
 {
-    TicketsSdkEmbeddedViewController *vc = [[TicketsSdkEmbeddedViewController alloc] init];
-  return vc.view;
+    self.ticketsViewController = [[TicketsSdkEmbeddedViewController alloc] init];
+
+    return self.ticketsViewController.view;
 }
-
-
 
 
 @end

--- a/ios/TicketsSdkEmbeddedViewController.swift
+++ b/ios/TicketsSdkEmbeddedViewController.swift
@@ -1,8 +1,7 @@
 import TicketmasterTickets
 
-public class TicketsSdkEmbeddedViewController: UIViewController, TMTicketsAnalyticsDelegate {
-    var ticketsView: TMTicketsView!
-    
+@objc public class TicketsSdkEmbeddedViewController: UIViewController, TMTicketsAnalyticsDelegate {
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -11,9 +10,9 @@ public class TicketsSdkEmbeddedViewController: UIViewController, TMTicketsAnalyt
 
         TMTickets.shared.configure {
             print(" - Tickets SDK Configured")
-            self.ticketsView = TMTicketsView.init(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: self.view.frame.height))
-            self.view.addSubview(self.ticketsView)
-            TMTickets.shared.start(ticketsView: self.ticketsView)
+            let ticketsView = TMTicketsView.init(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: self.view.frame.height))
+            self.view.addSubview(ticketsView)
+            TMTickets.shared.start(ticketsView: ticketsView)
         } failure: { error in
             print(" - Tickets SDK Configuration Error: \(error.localizedDescription)")
         }
@@ -25,11 +24,11 @@ public class TicketsSdkEmbeddedViewController: UIViewController, TMTicketsAnalyt
         
     }
     
+    
     func sendEvent(_ name: String, body: [String : Any]) {
         EventEmitter.emitter.sendEvent(withName: name, body: body)
     }
-    
-    
+
     public func userDidView(
         page: TMTickets.Analytics.Page,
         metadata: TMTickets.Analytics.MetadataType) {

--- a/ios/TicketsSdkViewController.swift
+++ b/ios/TicketsSdkViewController.swift
@@ -28,8 +28,7 @@ public class TicketsSdkViewController: UIViewController, TMTicketsAnalyticsDeleg
     func sendEvent(_ name: String, body: [String : Any]) {
         EventEmitter.emitter.sendEvent(withName: name, body: body)
     }
-    
-    
+
     public func userDidView(
         page: TMTickets.Analytics.Page,
         metadata: TMTickets.Analytics.MetadataType) {


### PR DESCRIPTION
Prevents premature deallocation of embedded tickets view controller by using a strong reference which fixes analytics not coming through in the `TicketsSdkEmbeddedViewController`.