### PR TITLE
fix: fix tests failing after the RN bump

### DIFF
--- a/__tests__/TicketsSdkEmbeddedIos.test.tsx
+++ b/__tests__/TicketsSdkEmbeddedIos.test.tsx
@@ -3,12 +3,6 @@ import { TicketsSdkEmbeddedIos } from '../src/TicketsSdkEmbeddedIos';
 import { render, waitFor } from '@testing-library/react-native';
 import { Platform } from 'react-native';
 
-jest.mock('react-native', () => {
-  const RN = jest.requireActual('react-native');
-  RN.requireNativeComponent = jest.fn();
-  return RN;
-});
-
 describe('TicketsSdkEmbeddedIos', () => {
   beforeAll(() => {
     Platform.OS = 'ios';

--- a/example/__mocks__/react-native-ticketmaster-ignite.tsx
+++ b/example/__mocks__/react-native-ticketmaster-ignite.tsx
@@ -31,11 +31,3 @@ export const TicketsSdkEmbeddedAndroid = jest.fn(() => {
     </View>
   );
 });
-
-export const TicketsSdkModal = jest.fn(() => {
-  return (
-    <View>
-      <Text>Hello Modal</Text>
-    </View>
-  );
-});

--- a/example/__tests__/components/AccountsSDKOptions.test.tsx
+++ b/example/__tests__/components/AccountsSDKOptions.test.tsx
@@ -3,6 +3,10 @@ import { render, fireEvent } from '@testing-library/react-native';
 import AccountsSDKOptions from '../../src/components/AccountsSDKOptions';
 import { useIgnite } from 'react-native-ticketmaster-ignite';
 
+jest.mock('react-native-ticketmaster-ignite', () => ({
+  useIgnite: jest.fn(),
+}));
+
 describe('AccountsSDKOptions', () => {
   const loginMock = jest.fn();
   const logoutMock = jest.fn();

--- a/example/__tests__/components/RetailSDKOptions.test.tsx
+++ b/example/__tests__/components/RetailSDKOptions.test.tsx
@@ -3,6 +3,14 @@ import { render, fireEvent } from '@testing-library/react-native';
 import RetailSDKOptions from '../../src/components/RetailSDKOptions';
 import { RetailSDK } from 'react-native-ticketmaster-ignite';
 
+jest.mock('react-native-ticketmaster-ignite', () => ({
+  RetailSDK: {
+    presentPrePurchaseVenue: jest.fn(),
+    presentPrePurchaseAttraction: jest.fn(),
+    presentPurchase: jest.fn(),
+  },
+}));
+
 describe('RetailSDKOptions', () => {
   it('calls presentPrePurchaseVenue with venue ID when Show Retail PrePurchase Venue is clicked', () => {
     const fakePresentPrePurchaseVenue = RetailSDK.presentPrePurchaseVenue;

--- a/example/__tests__/components/TicketsSDKOptions.test.tsx
+++ b/example/__tests__/components/TicketsSDKOptions.test.tsx
@@ -3,6 +3,19 @@ import { render, fireEvent } from '@testing-library/react-native';
 import TicketsSDKOptions from '../../src/components/TicketsSDKOptions';
 import { Platform } from 'react-native';
 
+jest.mock('react-native-ticketmaster-ignite', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    TicketsSdkModal: jest.fn(() => {
+      return (
+        <View>
+          <Text>Hello Modal</Text>
+        </View>
+      );
+    }),
+  };
+});
+
 describe('TicketsSDKOptions', () => {
   it('does not show the modal option on android', () => {
     Platform.OS = 'android';

--- a/example/__tests__/screens/Home.test.tsx
+++ b/example/__tests__/screens/Home.test.tsx
@@ -4,6 +4,10 @@ import Home from '../../src/screens/Home';
 import { useIgnite } from 'react-native-ticketmaster-ignite';
 import { ActivityIndicator } from 'react-native';
 
+jest.mock('react-native-ticketmaster-ignite');
+
+const mockedUseIgnite = useIgnite as jest.MockedFunction<typeof useIgnite>;
+
 describe('Home', () => {
   const loginMock = jest.fn();
   const logoutMock = jest.fn();
@@ -16,7 +20,7 @@ describe('Home', () => {
     jest.clearAllMocks();
 
     // @ts-ignore
-    useIgnite.mockReturnValue({
+    mockedUseIgnite.mockReturnValue({
       login: loginMock,
       logout: logoutMock,
       getToken: getTokenMock,
@@ -30,9 +34,13 @@ describe('Home', () => {
     describe('uses isLogging status to show spinner', () => {
       it('shows the ActivityIndicator when isLogging in is true', async () => {
         // @ts-ignore
-        useIgnite.mockReturnValue({
+        mockedUseIgnite.mockReturnValue({
           isLoggingIn: true,
-          authState: { isLoggedIn: false },
+          authState: {
+            isLoggedIn: false,
+            isConfigured: false,
+            memberInfo: null,
+          },
         });
 
         const component = render(<Home />);
@@ -46,9 +54,13 @@ describe('Home', () => {
 
       it('does not show the ActivityIndicator when isLogging in is false', async () => {
         // @ts-ignore
-        useIgnite.mockReturnValue({
+        mockedUseIgnite.mockReturnValue({
           isLoggingIn: false,
-          authState: { isLoggedIn: false },
+          authState: {
+            isLoggedIn: false,
+            isConfigured: false,
+            memberInfo: null,
+          },
         });
 
         const component = render(<Home />);

--- a/example/package.json
+++ b/example/package.json
@@ -34,7 +34,7 @@
     "@react-native/typescript-config": "0.76.1",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-hooks": "^8.0.1",
-    "@testing-library/react-native": "^11",
+    "@testing-library/react-native": "^12",
     "@tsconfig/react-native": "^3.0.0",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
@@ -52,6 +52,9 @@
   },
   "jest": {
     "preset": "react-native",
+    "moduleNameMapper": {
+      "^react-native$": "<rootDir>/node_modules/react-native"
+    },
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,18 @@
     ],
     "setupFilesAfterEnv": [
       "./jest-setup.ts"
-    ]
+    ],
+    "transform": {
+      "^.+\\.(js)$": [
+        "babel-jest",
+        {
+          "plugins": [
+            "babel-plugin-syntax-hermes-parser"
+          ]
+        }
+      ],
+      "^.+\\.(ts|tsx)$": "babel-jest"
+    }
   },
   "commitlint": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,6 +3162,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react-native@npm:^12":
+  version: 12.8.1
+  resolution: "@testing-library/react-native@npm:12.8.1"
+  dependencies:
+    jest-matcher-utils: ^29.7.0
+    pretty-format: ^29.7.0
+    redent: ^3.0.0
+  peerDependencies:
+    jest: ">=28.0.0"
+    react: ">=16.8.0"
+    react-native: ">=0.59"
+    react-test-renderer: ">=16.8.0"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 6f57fb2ea0cf70bf8882418c610b115b8a3deff908790ca54f10898c25e8158b19b5cdafe1ed24df9de9336699694baa919e2a64602a09e50710958432b493e9
+  languageName: node
+  linkType: hard
+
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node10@npm:1.0.11"
@@ -11636,7 +11655,7 @@ __metadata:
     "@react-navigation/native-stack": ^6.9.13
     "@testing-library/jest-native": ^5.4.3
     "@testing-library/react-hooks": ^8.0.1
-    "@testing-library/react-native": ^11
+    "@testing-library/react-native": ^12
     "@tsconfig/react-native": ^3.0.0
     "@types/react": ^18.2.6
     "@types/react-test-renderer": ^18.0.0
@@ -13596,7 +13615,7 @@ __metadata:
 
 "typescript@patch:typescript@^4.6.4 || ^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=14eedb"
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=29ae49"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver

--- a/yarn.lock
+++ b/yarn.lock
@@ -13615,7 +13615,7 @@ __metadata:
 
 "typescript@patch:typescript@^4.6.4 || ^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=29ae49"
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=14eedb"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver

--- a/yarn.lock
+++ b/yarn.lock
@@ -5818,9 +5818,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.41":
-  version: 1.5.58
-  resolution: "electron-to-chromium@npm:1.5.58"
-  checksum: 3d4f1574c882b281eadaefdc0c9970b1cf6966facb4f7decfee708b386c59dfbfa437f2b01a4def412178cae931db80574968e352f43d41a0689b69bd58d41e6
+  version: 1.5.60
+  resolution: "electron-to-chromium@npm:1.5.60"
+  checksum: 049764e0d3a459a312e203c8812e99041be510236467e4bc22d1fec67073e8191e6710b24b4dff980819effe3877b0666f00f5243d411cd1e5419886e7f904f6
   languageName: node
   linkType: hard
 
@@ -5936,8 +5936,8 @@ __metadata:
   linkType: hard
 
 "es-abstract@npm:^1.17.5, es-abstract@npm:^1.20.4, es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0, es-abstract@npm:^1.23.1, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3":
-  version: 1.23.4
-  resolution: "es-abstract@npm:1.23.4"
+  version: 1.23.5
+  resolution: "es-abstract@npm:1.23.5"
   dependencies:
     array-buffer-byte-length: ^1.0.1
     arraybuffer.prototype.slice: ^1.0.3
@@ -5985,7 +5985,7 @@ __metadata:
     typed-array-length: ^1.0.6
     unbox-primitive: ^1.0.2
     which-typed-array: ^1.1.15
-  checksum: 9ba2803b52a93d5e512962fcdfc648172c0f50417f0b2b8d3592a39109b0e685481ca24475cf1f3fedf1ce6f1a62c0c8885cb99b353ba5c3e8f16230c15e8f0a
+  checksum: 17c81f8a42f0322fd11e0025d3c2229ecfd7923560c710906b8e68660e19c42322750dcedf8ba5cf28bae50d5befd8174d3903ac50dbabb336d3efc3aabed2ee
   languageName: node
   linkType: hard
 
@@ -6815,9 +6815,9 @@ __metadata:
   linkType: hard
 
 "flow-parser@npm:0.*":
-  version: 0.252.0
-  resolution: "flow-parser@npm:0.252.0"
-  checksum: 01f6bdf16d500772b34343aa212ed4b8ba4483482b667284f61edaa776229cad8a1939e113791af343cabea73dc968197cd78381bfacb6c188c429646e880ef3
+  version: 0.253.0
+  resolution: "flow-parser@npm:0.253.0"
+  checksum: aec28d36de6847d1f110c6106aab4c18533cec2f9c4f18f93a9f879a61b725c8fb91f2a409b3533690aaa4915d98a6b134311cd83ee9b835b5c9dd4e26b3ac10
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13615,7 +13615,7 @@ __metadata:
 
 "typescript@patch:typescript@^4.6.4 || ^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
   version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=14eedb"
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#~builtin<compat/typescript>::version=5.6.3&hash=29ae49"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
After upgrading to RN v. 0.76.1 the tests started failing.

In the library the tests were failing with the following error: 

```vim
/react-native-ticketmaster-ignite/node_modules/react-native/Libraries/vendor/emitter/EventEmitter.js: Unexpected token, expected "]" (39:5)
```

It looks like an issue related to the newest release of RN that will soon be resolved. It's been already reported on the RN repo: https://github.com/facebook/react-native/issues/46355 

The fix applied is one recommended in that thread above ([direct link](https://github.com/facebook/react-native/issues/46355#issuecomment-2440024271)). 

------------------

In the example apps there were issues with the mocks. This MR changes the mocking strategy to work with the new versions. 

<img width="895" alt="Screenshot 2024-11-15 at 12 56 59" src="https://github.com/user-attachments/assets/9a77d483-0276-4246-b5f3-827b57071595">

