### PR TITLE
chore: bump ignite sdks

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -93,14 +93,14 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'androidx.compose.material:material:1.4.3'
+  implementation 'androidx.compose.material:material:1.7.4'
   implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
   implementation 'com.google.code.gson:gson:2.10.1'
 
-  implementation 'com.ticketmaster.accounts:authentication:3.9.0'
-  implementation 'com.ticketmaster.tickets:tickets:3.9.1'
-  implementation 'com.ticketmaster.tickets:secure-entry:1.2.10'
+  implementation 'com.ticketmaster.accounts:authentication:3.10.0'
+  implementation 'com.ticketmaster.tickets:tickets:3.10.0'
+  implementation 'com.ticketmaster.tickets:secure-entry:1.3.0'
   implementation 'com.ticketmaster.retail:purchase:3.2.0'
   implementation 'com.ticketmaster.retail:prepurchase:3.2.0'
   implementation 'com.ticketmaster.retail:discoveryapi:3.2.0'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -119,7 +119,6 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.compose.material:material:1.4.3'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     // The version of react-native is set by the React Native Gradle Plugin

--- a/react-native-ticketmaster-ignite.podspec
+++ b/react-native-ticketmaster-ignite.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
-  s.dependency "TM-Ignite", '= 1.11.2'
+  s.dependency "TM-Ignite", '= 1.11.3'
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
   else


### PR DESCRIPTION
**iOS**:  
`TM-Ignite = 1.11.3`
```
TicketmasterFoundation: 1.3.9
TicketmasterAuthentication: 3.9.2
TicketmasterDiscovery: 3.0.3
TicketmasterPrePurchase: 3.0.3
TicketmasterPurchase: 3.0.3
TicketmasterSecureEntry: 1.7.5
TicketmasterTickets: 3.9.3
```

**Android**:
```
  implementation 'com.ticketmaster.accounts:authentication:3.10.0'
  implementation 'com.ticketmaster.tickets:tickets:3.10.0'
  implementation 'com.ticketmaster.tickets:secure-entry:1.3.0'
  implementation 'com.ticketmaster.retail:purchase:3.2.0'
  implementation 'com.ticketmaster.retail:prepurchase:3.2.0'
  implementation 'com.ticketmaster.retail:discoveryapi:3.2.0'
  implementation 'com.ticketmaster.retail:foundation:3.2.0'
```