### PR TITLE
chore: upgrade ignite sdks (3.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Open the `AndroidManifest.xml` file and:
 </manifest>
 ```
 
-#### Set dataBinding to true
+#### Set dataBinding and coreLibraryDesugaringEnabled to true
 
 In `android/app/build.gradle` add:
 
@@ -100,6 +100,17 @@ android {
     buildFeatures {
         dataBinding = true
     }
+
+    compileOptions {
+      // Flag to enable support for the new language APIs
+      coreLibraryDesugaringEnabled true
+    }
+  ...
+}
+
+dependencies {
+  ...
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -721,6 +721,44 @@ const igniteAnalytics = async (data: IgniteAnalytics) => {
 </IgniteProvider>
 ```
 
+#### Navigate to a Tickets Tab after purchase
+
+This example uses [React Navigation](https://reactnavigation.org/docs/6.x/navigating-without-navigation-prop) and Redux Toolkit, you'll have to replace those code lines with your chosen navigation and state management methods.
+
+```typescript
+import {
+  IgniteAnalytics,
+  IgniteAnalyticName,
+} from 'react-native-ticketmaster-ignite';
+import * as RootNavigation from './RootNavigation';
+import { store } from '../redux/store';
+import { setExampleValue } from '../redux/slices/example';
+
+const igniteAnalytics = async (data: IgniteAnalytics) => {
+  const key = Object.keys(data)[0];
+  switch (key) {
+    // iOS
+    case IgniteAnalyticName.PURCHASE_SDK_DID_END_CHECKOUT_FOR:
+      if (
+        data.purchaseSdkDidEndCheckoutFor.reason === 'userCompletedPurchase'
+      ) {
+        store.dispatch('Random Value'); // Example - Not needed for navigation
+        RootNavigation.navigate('BottomTabs', {
+          screen: 'MY TICKETS',
+        });
+      }
+    // Android
+    case IgniteAnalyticName.PURCHASE_SDK_MANAGE_MY_TICKETS:
+      RootNavigation.navigate('BottomTabs', {
+        screen: 'MY TICKETS',
+      });
+      break;
+  }
+};
+```
+
+You may need to use a `setTimeout()` for iOS as if the SDK views are open it may block React Navigation from navigating in the background.
+
 ## Running the example app  
 
 To run the demo/example app:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,12 +99,12 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.10.1'
 
   implementation 'com.ticketmaster.accounts:authentication:3.10.0'
-  implementation 'com.ticketmaster.tickets:tickets:3.10.0'
-  implementation 'com.ticketmaster.tickets:secure-entry:1.3.0'
-  implementation 'com.ticketmaster.retail:purchase:3.2.0'
-  implementation 'com.ticketmaster.retail:prepurchase:3.2.0'
-  implementation 'com.ticketmaster.retail:discoveryapi:3.2.0'
-  implementation 'com.ticketmaster.retail:foundation:3.2.0'
+  implementation 'com.ticketmaster.tickets:tickets:3.10.2'
+  implementation 'com.ticketmaster.tickets:secure-entry:1.3.2'
+  implementation 'com.ticketmaster.retail:purchase:3.3.2'
+  implementation 'com.ticketmaster.retail:prepurchase:3.3.2'
+  implementation 'com.ticketmaster.retail:discoveryapi:3.3.2'
+  implementation 'com.ticketmaster.retail:foundation:3.3.2'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.mockito:mockito-core:4.1.0'

--- a/docs/expo.md
+++ b/docs/expo.md
@@ -13,13 +13,18 @@ const {
 
 module.exports = function withIgnitePlugin(expoConfig) {
   withAppBuildGradle(expoConfig, (config) => {
-    const lineChanges = [`buildFeatures {`, `dataBinding = true`, `}`].join(
-      '\n'
+    const buildGradleUpdates1 = [`buildFeatures {`, `dataBinding = true`, `}`, `compileOptions {`, `coreLibraryDesugaringEnabled true`, `}`].join(
+      "\n"
     );
 
     config.modResults.contents = config.modResults.contents.replace(
       `android {`,
-      `android {\n${lineChanges}`
+      `android {\n${buildGradleUpdates1}`
+    );
+
+    config.modResults.contents = config.modResults.contents.replace(
+      `dependencies {`,
+      `dependencies {\ncoreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'\n`
     );
 
     return config;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -80,6 +80,11 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
+    compileOptions {
+      // Flag to enable support for the new language APIs
+      coreLibraryDesugaringEnabled true
+    }
+
     namespace "com.ticketmasterigniteexample"
     defaultConfig {
         applicationId "com.ticketmasterigniteexample"
@@ -123,6 +128,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.3'
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/ios/PrePurchaseSDK.swift
+++ b/ios/PrePurchaseSDK.swift
@@ -45,10 +45,10 @@ class PrePurchaseSDK: UIViewController {
       
       if (self.venueId != "") {
         print("Set viewController to Venue")
-        viewController = TMPrePurchaseViewController.venueDetailsViewController(venueIdentifier: self.venueId, marketDomain: marketDomain, enclosingEnvironment: .modalPresentation)
+        viewController = TMPrePurchaseViewController.venueDetailsViewController(venueIdentifier: self.venueId, marketDomain: marketDomain, enclosingEnvironment: .modalPresentation, customFont: nil)
       } else {
         print("Set viewController to Attraction")
-        viewController = TMPrePurchaseViewController.attractionDetailsViewController(attractionIdentifier: self.attractionId, marketDomain: marketDomain, enclosingEnvironment: .modalPresentation)
+        viewController = TMPrePurchaseViewController.attractionDetailsViewController(attractionIdentifier: self.attractionId, marketDomain: marketDomain, enclosingEnvironment: .modalPresentation, customFont: nil)
       }
       
       viewController.modalPresentationStyle = .fullScreen

--- a/react-native-ticketmaster-ignite.podspec
+++ b/react-native-ticketmaster-ignite.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
-  s.dependency "TM-Ignite", '= 1.11.3'
+  s.dependency "TM-Ignite", '= 1.13.4'
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
   else


### PR DESCRIPTION
Changes needed to upgrade to Accounts and Tickets 3.10 on React Native iOS, Android and Expo