### PR TITLE
fix: navigating from Tickets SDK before load [ANDROID]

### DIFF
--- a/android/src/main/java/com/ticketmasterignite/tickets/TicketsViewManager.kt
+++ b/android/src/main/java/com/ticketmasterignite/tickets/TicketsViewManager.kt
@@ -90,12 +90,12 @@ class TicketsViewManager (
    * Layout all children properly
    */
   private fun manuallyLayoutChildren(view: View) {
-      view.measure(
-        View.MeasureSpec.makeMeasureSpec(propWidth, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(propHeight, View.MeasureSpec.EXACTLY))
-
-      view.layout(0, 0, propWidth, propHeight)
-      view.offsetTopAndBottom(propOffsetTop)
+    if (view == null || !view.isAttachedToWindow) return
+    view.measure(
+      View.MeasureSpec.makeMeasureSpec(propWidth, View.MeasureSpec.EXACTLY),
+      View.MeasureSpec.makeMeasureSpec(propHeight, View.MeasureSpec.EXACTLY))
+    view.layout(0, 0, propWidth, propHeight)
+    view.offsetTopAndBottom(propOffsetTop)
   }
 
   companion object {


### PR DESCRIPTION
Adds a null/attachment check in the manuallyLayoutChildren method.

This prevents measuring the view before it (and its child ComposeView) are attached to the window, which could cause a crash.