### PR TITLE
fix: custom modules image not showing on ios prod

### DIFF
--- a/ios/RCTNativeConfig.mm
+++ b/ios/RCTNativeConfig.mm
@@ -39,16 +39,13 @@
 - (UIImage *)getImage:(NSString *)key {
   NSString *imagePath = _configValues[key];
   if (!imagePath) return nil;
-  
-  if ([imagePath hasPrefix:@"file://"]) {
-    imagePath = [imagePath substringFromIndex:7];
-  }
-  
-  if ([imagePath hasPrefix:@"http"]) {
-    NSData *data = [NSData dataWithContentsOfURL:[NSURL URLWithString:imagePath]];
+
+  NSURL *url = [NSURL URLWithString:imagePath];
+  if (url.scheme) {
+    NSData *data = [NSData dataWithContentsOfURL:url];
     return data ? [UIImage imageWithData:data] : nil;
   }
-  
+
   return [UIImage imageWithContentsOfFile:imagePath];
 }
 


### PR DESCRIPTION
The header image passed via `customModules.headerView.image` to `IgniteProvider` doesn't render on iOS release builds. It works in debug and on Android.

The SDK's `RCTNativeConfig.getImage:` strips the `file://` prefix with a string slice and passes the result to `UIImage imageWithContentsOfFile:` — which takes a filesystem path, not a URL, and does not percent-decode. On release, expo-updates serves the asset from `Library/Application Support/.expo-internal/...`, so the URI contains `%20` for the space in "Application Support". The encoded space survives the strip and the file lookup fails.

This parses the value as an `NSURL` and use `dataWithContentsOfURL:` for any URL with a scheme, letting Foundation handle decoding. Bare filesystem paths still fall through to `imageWithContentsOfFile:`.


