### PR TITLE
fix: navigation bar and status bar overlap

### DIFF
--- a/android/src/main/java/com/ticketmasterignite/retail/PrePurchaseActivity.kt
+++ b/android/src/main/java/com/ticketmasterignite/retail/PrePurchaseActivity.kt
@@ -2,7 +2,11 @@ package com.ticketmasterignite.retail
 
 import android.os.Bundle
 import android.graphics.Color
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import com.ticketmasterignite.R
 import com.ticketmaster.discoveryapi.models.DiscoveryAbstractEntity
@@ -34,7 +38,16 @@ class PrePurchaseActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.prepurchase_layout)
+
+        val container = findViewById<View>(R.id.prepurchase_container)
+        container.setBackgroundColor(Color.BLACK)
+        ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
+            val statusBarHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+            view.setPadding(0, statusBarHeight, 0, 0)
+            insets
+        }
 
         val tmPrePurchase = TMPrePurchase(
                 environment = Environment.getTMEnvironment(Config.get("environment")),

--- a/android/src/main/java/com/ticketmasterignite/retail/PrePurchaseActivity.kt
+++ b/android/src/main/java/com/ticketmasterignite/retail/PrePurchaseActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import com.ticketmasterignite.R
 import com.ticketmaster.discoveryapi.models.DiscoveryAbstractEntity
@@ -39,15 +40,21 @@ class PrePurchaseActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars =
+            false
         setContentView(R.layout.prepurchase_layout)
 
         val container = findViewById<View>(R.id.prepurchase_container)
+        val initialPaddingTop = container.paddingTop
         container.setBackgroundColor(Color.BLACK)
         ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
-            val statusBarHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
-            view.setPadding(0, statusBarHeight, 0, 0)
+            val topInsets = insets.getInsets(
+                WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            view.updatePadding(top = initialPaddingTop + topInsets.top)
             insets
         }
+        ViewCompat.requestApplyInsets(container)
 
         val tmPrePurchase = TMPrePurchase(
                 environment = Environment.getTMEnvironment(Config.get("environment")),


### PR DESCRIPTION
The pre-purchase screen content was rendering behind the status bar on Android.

Changes:

Apply padding using both statusBars and displayCutout inset types to correctly handle notched/punch-hole devices
Use updatePadding instead of setPadding to avoid zeroing left/right/bottom padding
Force dark status bar icons (isAppearanceLightStatusBars = false) for readability against the black background
Call requestApplyInsets to ensure insets are dispatched immediately on layout