### PR TITLE
fix: remove RCTBridge instance dependency from Config, use static NativeConfig store

### DIFF
--- a/android/src/main/java/com/ticketmasterignite/Config.kt
+++ b/android/src/main/java/com/ticketmasterignite/Config.kt
@@ -14,6 +14,7 @@ object Config {
     }
   }
 
+  // We want to return null to the SDK's Prebuilt Modules if no image overlay text is provided to enable the SDK's default text
   fun optionalString(key: String): String? {
     return configValues[key]
   }

--- a/ios/Config.swift
+++ b/ios/Config.swift
@@ -1,24 +1,23 @@
 import Foundation
-import React
 
 @objc
 final class Config: NSObject {
-  
+
   static let shared = Config()
-  
+
   func get(for key: String) -> String {
-    return RCTNativeConfig.getConfig(key) ?? ""
+    return RCTNativeConfig.sharedInstance()?.getConfig(key) ?? ""
   }
 
   func set(for key: String, value: String) {
-    RCTNativeConfig.setConfig(value, forKey: key)
+    RCTNativeConfig.sharedInstance()?.setConfig(key, value: value)
   }
 
   func optionalString(for key: String) -> String? {
-    return RCTNativeConfig.getConfig(key)
+    return RCTNativeConfig.sharedInstance()?.getConfig(key)
   }
 
   func getImage(for key: String) -> UIImage? {
-    return RCTNativeConfig.getImage(key)
+    return RCTNativeConfig.sharedInstance()?.getImage(key)
   }
 }

--- a/ios/Config.swift
+++ b/ios/Config.swift
@@ -7,18 +7,18 @@ final class Config: NSObject {
   static let shared = Config()
   
   func get(for key: String) -> String {
-    return RCTNativeConfig.getConfig(forKey: key) ?? ""
+    return RCTNativeConfig.getForKey(key) ?? ""
   }
-  
+
   func set(for key: String, value: String) {
     RCTNativeConfig.setConfig(value, forKey: key)
   }
-  
+
   func optionalString(for key: String) -> String? {
-    return RCTNativeConfig.getConfig(forKey: key)
+    return RCTNativeConfig.getForKey(key)
   }
-  
+
   func getImage(for key: String) -> UIImage? {
-    return RCTNativeConfig.getImage(forKey: key)
+    return RCTNativeConfig.getImageForKey(key)
   }
 }

--- a/ios/Config.swift
+++ b/ios/Config.swift
@@ -7,7 +7,7 @@ final class Config: NSObject {
   static let shared = Config()
   
   func get(for key: String) -> String {
-    return RCTNativeConfig.getForKey(key) ?? ""
+    return RCTNativeConfig.getConfig(key) ?? ""
   }
 
   func set(for key: String, value: String) {
@@ -15,10 +15,10 @@ final class Config: NSObject {
   }
 
   func optionalString(for key: String) -> String? {
-    return RCTNativeConfig.getForKey(key)
+    return RCTNativeConfig.getConfig(key)
   }
 
   func getImage(for key: String) -> UIImage? {
-    return RCTNativeConfig.getImageForKey(key)
+    return RCTNativeConfig.getImage(key)
   }
 }

--- a/ios/Config.swift
+++ b/ios/Config.swift
@@ -13,6 +13,7 @@ final class Config: NSObject {
     RCTNativeConfig.sharedInstance()?.setConfig(key, value: value)
   }
 
+  // We want to return null to the SDK's Prebuilt Modules if no image overlay text is provided to enable the SDK's default text
   func optionalString(for key: String) -> String? {
     return RCTNativeConfig.sharedInstance()?.getConfig(key)
   }

--- a/ios/Config.swift
+++ b/ios/Config.swift
@@ -6,25 +6,19 @@ final class Config: NSObject {
   
   static let shared = Config()
   
-  private var nativeConfig: RCTNativeConfig? {
-    RCTBridge.current()?.module(forName: "NativeConfig") as? RCTNativeConfig
-  }
-  
   func get(for key: String) -> String {
-    return nativeConfig?.getConfig(key) ?? ""
+    return RCTNativeConfig.getConfig(forKey: key) ?? ""
   }
   
   func set(for key: String, value: String) {
-    print("Swift set key=\(key) value=\(value)")
-    nativeConfig?.setConfig(key, value: value)
+    RCTNativeConfig.setConfig(value, forKey: key)
   }
   
   func optionalString(for key: String) -> String? {
-    let value = nativeConfig?.getConfig(key)
-    return value == nil ? nil : value
+    return RCTNativeConfig.getConfig(forKey: key)
   }
   
   func getImage(for key: String) -> UIImage? {
-    return nativeConfig?.getImage(key)
+    return RCTNativeConfig.getImage(forKey: key)
   }
 }

--- a/ios/MarketDomain.swift
+++ b/ios/MarketDomain.swift
@@ -2,10 +2,9 @@ import TicketmasterFoundation
 
 class MarketDomainObject {
   static let shared = MarketDomainObject()
-  
-  let marketDomain = Config.shared.get(for: "marketDomain")
-  
+
   func getMarketDomain() -> TicketmasterFoundation.MarketDomain {
+    let marketDomain = Config.shared.get(for: "marketDomain")
     return MarketDomain(countryCode: marketDomain.lowercased()) ?? MarketDomain.US
   }
 }

--- a/ios/RCTNativeConfig.h
+++ b/ios/RCTNativeConfig.h
@@ -7,8 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTNativeConfig : NSObject <NativeConfigSpec>
 
-- (NSString *)getConfig:(NSString *)key;
-- (UIImage *)getImage:(NSString *)key;
 - (void)setConfig:(NSString *)key value:(NSString *)value;
 - (void)setImage:(NSString *)key uri:(NSString *)uri;
 

--- a/ios/RCTNativeConfig.h
+++ b/ios/RCTNativeConfig.h
@@ -12,6 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setConfig:(NSString *)key value:(NSString *)value;
 - (void)setImage:(NSString *)key uri:(NSString *)uri;
 
++ (nullable NSString *)getConfigForKey:(NSString *)key;
++ (void)setConfig:(nullable NSString *)value forKey:(NSString *)key;
++ (nullable UIImage *)getImageForKey:(NSString *)key;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/RCTNativeConfig.h
+++ b/ios/RCTNativeConfig.h
@@ -7,12 +7,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTNativeConfig : NSObject <NativeConfigSpec>
 
++ (nullable instancetype)sharedInstance;
+
+- (NSString *)getConfig:(NSString *)key;
+- (UIImage *)getImage:(NSString *)key;
 - (void)setConfig:(NSString *)key value:(NSString *)value;
 - (void)setImage:(NSString *)key uri:(NSString *)uri;
-
-+ (nullable NSString *)getConfig:(NSString *)key;
-+ (nullable UIImage *)getImage:(NSString *)key;
-+ (void)setConfig:(nullable NSString *)value forKey:(NSString *)key;
 
 @end
 

--- a/ios/RCTNativeConfig.h
+++ b/ios/RCTNativeConfig.h
@@ -14,9 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSString *)getConfig:(NSString *)key;
 + (nullable UIImage *)getImage:(NSString *)key;
-+ (nullable NSString *)getConfigForKey:(NSString *)key;
 + (void)setConfig:(nullable NSString *)value forKey:(NSString *)key;
-+ (nullable UIImage *)getImageForKey:(NSString *)key;
 
 @end
 

--- a/ios/RCTNativeConfig.h
+++ b/ios/RCTNativeConfig.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setConfig:(NSString *)key value:(NSString *)value;
 - (void)setImage:(NSString *)key uri:(NSString *)uri;
 
++ (nullable NSString *)getConfig:(NSString *)key;
++ (nullable UIImage *)getImage:(NSString *)key;
 + (nullable NSString *)getConfigForKey:(NSString *)key;
 + (void)setConfig:(nullable NSString *)value forKey:(NSString *)key;
 + (nullable UIImage *)getImageForKey:(NSString *)key;

--- a/ios/RCTNativeConfig.mm
+++ b/ios/RCTNativeConfig.mm
@@ -4,54 +4,64 @@
 #import <ReactCommon/RCTTurboModule.h>
 #import <TicketmasterIgniteSpecs/TicketmasterIgniteSpecs.h>
 
-static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
-  static NSMutableDictionary<NSString *, NSString *> *store = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    store = [NSMutableDictionary new];
-  });
-  return store;
+static RCTNativeConfig *_sharedInstance = nil;
+
+@implementation RCTNativeConfig {
+  NSMutableDictionary<NSString *, NSString *> *_store;
 }
 
+- (instancetype)init {
+  if (self = [super init]) {
+    _store = [NSMutableDictionary new];
+    _sharedInstance = self;
+  }
+  return self;
+}
 
-@implementation RCTNativeConfig
++ (nullable instancetype)sharedInstance {
+  return _sharedInstance;
+}
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
-(const facebook::react::ObjCTurboModule::InitParams &)params
+    (const facebook::react::ObjCTurboModule::InitParams &)params
 {
   return std::make_shared<facebook::react::NativeConfigSpecJSI>(params);
 }
 
-
 - (void)setConfig:(NSString *)key value:(NSString *)value {
-  [RCTNativeConfig setConfig:value forKey:key];
-}
-
-- (void)setImage:(NSString *)key uri:(NSString *)uri {
-  [RCTNativeConfig setConfig:uri forKey:key];
-}
-
-
-+ (NSString *)getConfig:(NSString *)key {
-  if (!key) return nil;
-  @synchronized (NativeConfigStore()) {
-    return NativeConfigStore()[key];
-  }
-}
-
-+ (void)setConfig:(nullable NSString *)value forKey:(NSString *)key {
   if (!key) return;
-  @synchronized (NativeConfigStore()) {
+  @synchronized (_store) {
     if (value) {
-      NativeConfigStore()[key] = value;
+      _store[key] = value;
     } else {
-      [NativeConfigStore() removeObjectForKey:key];
+      [_store removeObjectForKey:key];
     }
   }
 }
 
-+ (UIImage *)getImage:(NSString *)key {
-  NSString *imagePath = [RCTNativeConfig getConfig:key];
+- (void)setImage:(NSString *)key uri:(NSString *)uri {
+  if (!key) return;
+  @synchronized (_store) {
+    if (uri) {
+      _store[key] = uri;
+    } else {
+      [_store removeObjectForKey:key];
+    }
+  }
+}
+
+- (NSString *)getConfig:(NSString *)key {
+  if (!key) return nil;
+  @synchronized (_store) {
+    return _store[key];
+  }
+}
+
+- (UIImage *)getImage:(NSString *)key {
+  NSString *imagePath;
+  @synchronized (_store) {
+    imagePath = _store[key];
+  }
   if (!imagePath) return nil;
 
   NSURL *url = [NSURL URLWithString:imagePath];
@@ -63,8 +73,7 @@ static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
   return [UIImage imageWithContentsOfFile:imagePath];
 }
 
-+ (NSString *)moduleName
-{
++ (NSString *)moduleName {
   return @"NativeConfig";
 }
 

--- a/ios/RCTNativeConfig.mm
+++ b/ios/RCTNativeConfig.mm
@@ -33,22 +33,14 @@ static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
 
 
 - (NSString *)getConfig:(NSString *)key {
-  return [RCTNativeConfig getConfigForKey:key];
+  return [RCTNativeConfig getConfig:key];
 }
 
 - (UIImage *)getImage:(NSString *)key {
-  return [RCTNativeConfig getImageForKey:key];
+  return [RCTNativeConfig getImage:key];
 }
 
 + (NSString *)getConfig:(NSString *)key {
-  return [RCTNativeConfig getConfigForKey:key];
-}
-
-+ (UIImage *)getImage:(NSString *)key {
-  return [RCTNativeConfig getImageForKey:key];
-}
-
-+ (NSString *)getConfigForKey:(NSString *)key {
   if (!key) return nil;
   @synchronized (NativeConfigStore()) {
     return NativeConfigStore()[key];
@@ -66,8 +58,8 @@ static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
   }
 }
 
-+ (UIImage *)getImageForKey:(NSString *)key {
-  NSString *imagePath = [RCTNativeConfig getConfigForKey:key];
++ (UIImage *)getImage:(NSString *)key {
+  NSString *imagePath = [RCTNativeConfig getConfig:key];
   if (!imagePath) return nil;
 
   NSURL *url = [NSURL URLWithString:imagePath];

--- a/ios/RCTNativeConfig.mm
+++ b/ios/RCTNativeConfig.mm
@@ -32,14 +32,6 @@ static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
 }
 
 
-- (NSString *)getConfig:(NSString *)key {
-  return [RCTNativeConfig getConfig:key];
-}
-
-- (UIImage *)getImage:(NSString *)key {
-  return [RCTNativeConfig getImage:key];
-}
-
 + (NSString *)getConfig:(NSString *)key {
   if (!key) return nil;
   @synchronized (NativeConfigStore()) {

--- a/ios/RCTNativeConfig.mm
+++ b/ios/RCTNativeConfig.mm
@@ -40,6 +40,14 @@ static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
   return [RCTNativeConfig getImageForKey:key];
 }
 
++ (NSString *)getConfig:(NSString *)key {
+  return [RCTNativeConfig getConfigForKey:key];
+}
+
++ (UIImage *)getImage:(NSString *)key {
+  return [RCTNativeConfig getImageForKey:key];
+}
+
 + (NSString *)getConfigForKey:(NSString *)key {
   if (!key) return nil;
   @synchronized (NativeConfigStore()) {

--- a/ios/RCTNativeConfig.mm
+++ b/ios/RCTNativeConfig.mm
@@ -4,17 +4,17 @@
 #import <ReactCommon/RCTTurboModule.h>
 #import <TicketmasterIgniteSpecs/TicketmasterIgniteSpecs.h>
 
-
-@implementation RCTNativeConfig {
-  NSMutableDictionary *_configValues;
+static NSMutableDictionary<NSString *, NSString *> *NativeConfigStore(void) {
+  static NSMutableDictionary<NSString *, NSString *> *store = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    store = [NSMutableDictionary new];
+  });
+  return store;
 }
 
-- (instancetype)init {
-  if (self = [super init]) {
-    _configValues = [NSMutableDictionary new];
-  }
-  return self;
-}
+
+@implementation RCTNativeConfig
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
 (const facebook::react::ObjCTurboModule::InitParams &)params
@@ -24,20 +24,42 @@
 
 
 - (void)setConfig:(NSString *)key value:(NSString *)value {
-  _configValues[key] = value;
+  [RCTNativeConfig setConfig:value forKey:key];
 }
 
 - (void)setImage:(NSString *)key uri:(NSString *)uri {
-  _configValues[key] = uri;
+  [RCTNativeConfig setConfig:uri forKey:key];
 }
 
 
 - (NSString *)getConfig:(NSString *)key {
-  return _configValues[key];
+  return [RCTNativeConfig getConfigForKey:key];
 }
 
 - (UIImage *)getImage:(NSString *)key {
-  NSString *imagePath = _configValues[key];
+  return [RCTNativeConfig getImageForKey:key];
+}
+
++ (NSString *)getConfigForKey:(NSString *)key {
+  if (!key) return nil;
+  @synchronized (NativeConfigStore()) {
+    return NativeConfigStore()[key];
+  }
+}
+
++ (void)setConfig:(nullable NSString *)value forKey:(NSString *)key {
+  if (!key) return;
+  @synchronized (NativeConfigStore()) {
+    if (value) {
+      NativeConfigStore()[key] = value;
+    } else {
+      [NativeConfigStore() removeObjectForKey:key];
+    }
+  }
+}
+
++ (UIImage *)getImageForKey:(NSString *)key {
+  NSString *imagePath = [RCTNativeConfig getConfigForKey:key];
   if (!imagePath) return nil;
 
   NSURL *url = [NSURL URLWithString:imagePath];


### PR DESCRIPTION
Replaces the RCTBridge-based instance lookup in Config.swift with direct static class method calls on RCTNativeConfig, backed by a thread-safe singleton store. 

RCTBridge.current() was removed in React Native 0.85, making this change required for compatibility. 

The static store approach is functionally equivalent and backwards compatible with earlier RN versions.