### PR TITLE
ci: retry iOS platform download to work around runner flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,20 @@ jobs:
         with:
           xcode-version: '26.1.1'
 
+      # Intermittently fails with "Unable to connect to simulator" on GitHub
+      # macOS runners (actions/runner-images#13459), so retry a few times
       - name: Install iOS platform
-        run: sudo xcodebuild -downloadPlatform iOS
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if sudo xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed, retrying in 15s..."
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService 2>/dev/null || true
+            sleep 15
+          done
+          echo "Failed to install iOS platform after 5 attempts"
+          exit 1
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Why

The `build-ios` job fails intermittently at the **Install iOS platform** step:

```
Finding content...
Unable to connect to simulator.
Process completed with exit code 70.
```

This is a known GitHub runner flake (actions/runner-images#13459) affecting `xcodebuild -downloadPlatform iOS` on macOS runners — it fails ~40% of the time with no code change involved. Both attempts of the `chore: release 4.4.2` run on `main` hit it (https://github.com/ticketmaster/react-native-ticketmaster-ignite/actions/runs/29495140098), while the identical run the day before passed.

## What

Retry the platform download up to 5 times, resetting `CoreSimulatorService` between attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)